### PR TITLE
Add automated backup workflow

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -1,0 +1,33 @@
+name: Backup
+
+on:
+  schedule:
+    - cron: '5 4 * * 0'
+
+  workflow_dispatch:
+
+jobs:
+  backup:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Configure cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ${{ env.GITHUB_WORKSPACE }}
+            ~/.cache/restic
+          key: ${{ runner.os }}
+
+      - name: Install the correct Python version
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Run backup action
+        uses: julia-actions/restic-action@main
+        env: # Options: https://restic.readthedocs.io/en/latest/040_backup.html#environment-variables
+          RESTIC_REPOSITORY: b2:${{ secrets.B2_BUCKET }}:${{ github.repository }}
+          RESTIC_PASSWORD: ${{ secrets.RESTIC_PASSWORD }}
+          B2_ACCOUNT_ID: ${{ secrets.B2_ACCOUNT_ID }}
+          B2_ACCOUNT_KEY: ${{ secrets.B2_ACCOUNT_KEY }}


### PR DESCRIPTION
This PR adds an automated weekly backup for all repo data, including issues and PRs. I'm adding these across all repos in julia-actions since I personally find it useful to not fully rely on GitHub for backups for my own projects, also for peace of mind. If you don't want this, just close the PR, I don't want to force these on anyone, just offer it :)

Details:
- The data is downloaded from the API using [python-github-backup](https://github.com/josegonzalez/python-github-backup) and only includes publicly accessible info,
- it is then passed into [restic](https://github.com/restic/restic) for deduplication and encryption,
- and finally it's uploaded into a [Backblaze B2 Bucket](https://www.backblaze.com/b2/cloud-storage.html) (comparable to AWS S3 but cheaper).
- The credentials are accessible as org secrets. I'll happily create you an extra set of keys if you want, though.
- If you need to restore anything, you can either use the org secrets and restore it yourself, or ask me and I'll do it for you.
- The B2 bucket is on very strict cost limits, so please don't increase the frequency of the builds.
- This is somewhat experimental. If it turns out to be too expensive, I may remove them again.
