### PR TITLE
Fix the build script to handle macOS `sed` correctly

### DIFF
--- a/build-release.sh
+++ b/build-release.sh
@@ -30,7 +30,12 @@ npm run build
 npm test
 npm run pack
 
-sed -i 's/dist/!dist/g' .gitignore
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    sed -i '' 's/dist/!dist/g' .gitignore
+else
+    sed -i 's/dist/!dist/g' .gitignore
+fi
 git add dist
 git commit -a -m "Add production dependencies & build"
 

--- a/build-release.sh
+++ b/build-release.sh
@@ -31,7 +31,7 @@ npm test
 npm run pack
 
 
-if [[ "$OSTYPE" == "darwin"* ]]; then
+if [[ "${OSTYPE:}" == "darwin"* ]]; then
     sed -i '' 's/dist/!dist/g' .gitignore
 else
     sed -i 's/dist/!dist/g' .gitignore


### PR DESCRIPTION
Otherwise on MacOS it fails with `sed: 1: ".gitignore": invalid command code .`