### PR TITLE
More build script fixes and tweaks

### DIFF
--- a/build-release.sh
+++ b/build-release.sh
@@ -1,37 +1,57 @@
-#!/bin/sh
+#!/usr/bin/env bash
+
+set -euf -o pipefail
+
+set +u
+repo="$1"
+set -u
+
+# Uncomment the following line to help when debugging
+# set -x
+
+# Make sure all dependencies exist
+which curl
+which git
+which jq
+which npm
+which sed
 
 branch_name="$(git symbolic-ref --short -q HEAD)"
-version="v$(jq -r .version package.json)"
-repo="$1"
+_version_without_v="$(jq -r .version package.json)"
+# A quick sanity check to make sure
+# that _version_without_v is not
+# empty.
+version="v${_version_without_v:?}"
 
-if [ -z "$repo" ]; then
+if [ -z "${repo}" ]; then
     echo "ERROR: must specify repository"
+    echo "Usage: ./bin/build-release.sh orgname/reponame"
     exit 1
 fi
 
 echo "=== debug info ==="
-echo "branch: $branch_name"
-echo "version: $version"
-echo "repo: $repo"
+echo "branch: ${branch_name:?}"
+echo "version: ${version:?}"
+echo "repo: ${repo:?}"
+echo "ostype: ${OSTYPE:?}"
 echo "=================="
 echo ""
 
 # Check that the version doesn't exist yet
 version_exists="$(curl -s https://api.github.com/repos/"$repo"/tags -H "Accept: application/vnd.github.v3.full+json" | jq -r '.[] | select(.name == "'"$version"'") | .name')"
-if [ -n "$version_exists" ]; then
-    echo "ERROR: version $version already exists"
+if [ -n "${version_exists}" ]; then # We intentionall don't do `:?` here, because we know `version_exists` might be empty
+    echo "ERROR: version ${version:?} already exists"
     exit 1
 fi
 
-git checkout -b releases/"$version"
+git checkout -b releases/"${version:?}"
 
 npm install
 npm run build
 npm test
 npm run pack
 
-
-if [[ "${OSTYPE:}" == "darwin"* ]]; then
+if [[ "${OSTYPE:?}" == "darwin"* ]]; then
     sed -i '' 's/dist/!dist/g' .gitignore
 else
     sed -i 's/dist/!dist/g' .gitignore
@@ -43,7 +63,10 @@ git commit -a -m "Add production dependencies & build"
 major_minor="$(sed 's/\.[^.]*$//' <<< "$version")"
 major="$(sed 's/\.[^.]*$//' <<< "$major_minor")"
 
-git tag "$version"
-git tag -f "$major_minor"
-git tag -f "$major"
+# For this tag, we intentionally do NOT force tag:
+git tag "${version:?}"
+
+# For the remaining tags, we need to force tag:
+git tag -f "${major_minor:?}"
+git tag -f "${major:?}"
 git tag -f "latest"


### PR DESCRIPTION
1. Explicitly use Bash, instead of worrying about being compatible with any shell.
2. Use `${foo:?}` whenever possible, to make sure that variables are defined and not empty.
3. At the beginning of the script, make sure all dependencies exist, before we start running any commands.

Also includes the macOS `sed` fix from #8.